### PR TITLE
test: cover compile helper paths

### DIFF
--- a/tests/compile.test.js
+++ b/tests/compile.test.js
@@ -5,6 +5,7 @@ import test from "node:test";
 import { pathToFileURL } from "node:url";
 
 import {
+  getAikenArtifactPaths,
   getContractArtifactPaths,
   resolveOptimizeFlag,
 } from "../compileHelpers.js";
@@ -45,6 +46,27 @@ test("getContractArtifactPaths handles trailing and non-trailing slash", () => {
   assert.equal(withSlash.directory, "./contract");
   assert.equal(noSlash.json, "./contract/contract.json");
   assert.equal(withSlash.uplc, "./contract/contract.uplc");
+});
+
+test("getAikenArtifactPaths returns the full Aiken artifact bundle", () => {
+  const defaultPaths = getAikenArtifactPaths();
+  const withSlash = getAikenArtifactPaths("./contract/");
+
+  assert.deepEqual(defaultPaths, {
+    directory: "./contract",
+    blueprint: "./contract/aiken.plutus.json",
+    validators: "./contract/aiken.validators.json",
+    addresses: "./contract/aiken.addresses.json",
+    spendHash: "./contract/aiken.spend.hash",
+    spendAddrTestnet: "./contract/aiken.spend.addr_testnet",
+    spendAddrMainnet: "./contract/aiken.spend.addr_mainnet",
+    withdrawHash: "./contract/aiken.withdraw.hash",
+    withdrawStakeAddrTestnet: "./contract/aiken.withdraw.stake_addr_testnet",
+    withdrawStakeAddrMainnet: "./contract/aiken.withdraw.stake_addr_mainnet",
+  });
+  assert.equal(withSlash.directory, "./contract");
+  assert.equal(withSlash.blueprint, "./contract/aiken.plutus.json");
+  assert.equal(withSlash.withdrawStakeAddrMainnet, "./contract/aiken.withdraw.stake_addr_mainnet");
 });
 
 test("compile.js creates contract artifacts with optimize disabled", async () => {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -456,7 +456,9 @@ export class PzFixture extends Fixture {
                     hasAsset(input, bgAsset.policyId, `${AssetNameLabel.LBL_100}${bgAsset.assetName.slice(8)}`)
             ),
             refInputIndex((input) => hasAsset(input, PFP_POLICY_ID, `${AssetNameLabel.LBL_222}${Buffer.from("pfp").toString('hex')}`)),
-            refInputIndex((input) => hasAsset(input, POLICY_ID, `${AssetNameLabel.LBL_001}${Buffer.from(rootHandleName).toString('hex')}`)),
+            rootHandleName
+                ? refInputIndex((input) => hasAsset(input, POLICY_ID, `${AssetNameLabel.LBL_001}${Buffer.from(rootHandleName).toString('hex')}`))
+                : 0,
             0,
             1,
             3


### PR DESCRIPTION
Coverage rotation for handles-personalization.

- Discovered repo-local tooling: test_coverage.sh uses node --test --experimental-test-coverage tests/compile.test.js over compile.js/compileHelpers.js; npm test is the final gate.
- Added coverage for getAikenArtifactPaths and guarded the PzFixture owner-settings index when a Handle has no subhandle root so npm test can complete.

Verify: npm test exited 0; focused node coverage reported all files lines 99.34%, branches 94.44%, functions 100%.
Lesson: coverage-rotation-local-tooling-first