### PR TITLE
Remediate npm audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-personalization",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
@@ -800,72 +800,32 @@
                 "npm": ">=7.0.0"
             }
         },
-        "node_modules/@cardano-ogmios/client": {
-            "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.9.0.tgz",
-            "integrity": "sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@cardano-ogmios/schema": "6.9.0",
-                "@cardanosolutions/json-bigint": "^1.0.1",
-                "@types/json-bigint": "^1.0.1",
-                "bech32": "^2.0.0",
-                "cross-fetch": "^3.1.4",
-                "fastq": "^1.11.0",
-                "isomorphic-ws": "^4.0.1",
-                "nanoid": "^3.1.31",
-                "ts-custom-error": "^3.2.0",
-                "ws": "^7.5.10"
-            },
-            "engines": {
-                "node": ">=14"
-            }
-        },
-        "node_modules/@cardano-ogmios/schema": {
-            "version": "6.9.0",
-            "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.9.0.tgz",
-            "integrity": "sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA==",
-            "license": "MPL-2.0",
-            "engines": {
-                "node": ">=14"
-            }
-        },
         "node_modules/@cardano-sdk/core": {
-            "version": "0.46.12",
-            "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.12.tgz",
-            "integrity": "sha512-yUA/xBUQMiMqIWiZPvIhM911pL3jNKg4PkZQ8qP9R7yU3NQ5x4RQkZ+zFDlVLxUt+gJiwIW2es0iPd8ObIKCxA==",
+            "version": "0.46.15",
+            "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.15.tgz",
+            "integrity": "sha512-ubfUpDaSSEGxfmdCvV8xN7niXy1cR3HX4dCA/zJH91GpuV5XGGttI5pFbxpqDZubYHU2lw+QQ2kWJJGHQmjbog==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@biglup/is-cid": "^1.0.3",
-                "@cardano-ogmios/client": "6.9.0",
-                "@cardano-ogmios/schema": "6.9.0",
-                "@cardano-sdk/crypto": "~0.4.5",
-                "@cardano-sdk/util": "~0.17.1",
+                "@cardano-sdk/crypto": "~0.4.7",
+                "@cardano-sdk/util": "~0.17.2",
                 "@foxglove/crc": "^0.0.3",
                 "@scure/base": "^1.1.1",
                 "fraction.js": "4.0.1",
-                "ip-address": "^9.0.5",
+                "ip-address": "^10.2.0",
                 "lodash": "^4.17.21",
                 "ts-custom-error": "^3.2.0",
                 "ts-log": "^2.2.4",
                 "web-encoding": "^1.1.5"
             },
             "engines": {
-                "node": ">=16.20.2"
-            },
-            "peerDependencies": {
-                "rxjs": "^7.4.0"
-            },
-            "peerDependenciesMeta": {
-                "rxjs": {
-                    "optional": true
-                }
+                "node": ">=22"
             }
         },
         "node_modules/@cardano-sdk/core/node_modules/@cardano-sdk/util": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.1.tgz",
-            "integrity": "sha512-TCYe+wRguW1WgRlbWqhGPhcSBkzVzdIcCVgDDN7wiQk2dew0EWVqjsKeqDZdfwzy/s2kr/ZOgXIGywBn/Bzu/Q==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.2.tgz",
+            "integrity": "sha512-LdY33OQG5H4p0rppHtjnM+akc1poKhz+02T9zsXsbShfTbeU9HXlA0nJ8xj9FNZMs+ozDR0HWrUjDc7fkNZI7w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",
@@ -875,26 +835,26 @@
                 "ts-log": "^2.2.4"
             },
             "engines": {
-                "node": ">=16.20.2"
+                "node": ">=22"
             }
         },
         "node_modules/@cardano-sdk/crypto": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.5.tgz",
-            "integrity": "sha512-ymliqxdmen5dGVaiMVQ0VnhrwaYUjbPD3sHoMj8NI6MTuxrREp3pLJASREtWhwmv9k+QzDT6CoyuIXnlEQiWZQ==",
+            "version": "0.4.7",
+            "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.7.tgz",
+            "integrity": "sha512-4aCsLOkqaIS/gSGw4SBqNGcCIp6hZ8alQWJx58U/OiOxC43t7i2JpKagdyWfCNekPM14hO7BWER7y31wf4BFxw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cardano-sdk/util": "~0.17.1",
+                "@cardano-sdk/util": "~0.17.2",
                 "blake2b": "^2.1.4",
                 "i": "^0.3.7",
-                "libsodium-wrappers-sumo": "0.7.10",
+                "libsodium-wrappers-sumo": "0.8.4",
                 "lodash": "^4.17.21",
                 "pbkdf2": "^3.1.3",
                 "ts-custom-error": "^3.2.0",
                 "ts-log": "^2.2.4"
             },
             "engines": {
-                "node": ">=16.20.2"
+                "node": ">=22"
             },
             "peerDependencies": {
                 "@dcspark/cardano-multiplatform-lib-asmjs": "^3.1.1",
@@ -914,9 +874,9 @@
             }
         },
         "node_modules/@cardano-sdk/crypto/node_modules/@cardano-sdk/util": {
-            "version": "0.17.1",
-            "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.1.tgz",
-            "integrity": "sha512-TCYe+wRguW1WgRlbWqhGPhcSBkzVzdIcCVgDDN7wiQk2dew0EWVqjsKeqDZdfwzy/s2kr/ZOgXIGywBn/Bzu/Q==",
+            "version": "0.17.2",
+            "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.2.tgz",
+            "integrity": "sha512-LdY33OQG5H4p0rppHtjnM+akc1poKhz+02T9zsXsbShfTbeU9HXlA0nJ8xj9FNZMs+ozDR0HWrUjDc7fkNZI7w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bech32": "^2.0.0",
@@ -926,7 +886,7 @@
                 "ts-log": "^2.2.4"
             },
             "engines": {
-                "node": ">=16.20.2"
+                "node": ">=22"
             }
         },
         "node_modules/@cardano-sdk/dapp-connector": {
@@ -1119,12 +1079,6 @@
             "engines": {
                 "node": ">=16.20.2"
             }
-        },
-        "node_modules/@cardanosolutions/json-bigint": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@cardanosolutions/json-bigint/-/json-bigint-1.1.0.tgz",
-            "integrity": "sha512-Pdgz18cSwLKKgheOqW/dqbzNI+CliNT4AdaKaKY/P++J9qLxIB8MITCurlzbaFWV3W4nmK0CRQwI1yvuArmjFg==",
-            "license": "MIT"
         },
         "node_modules/@chainsafe/is-ip": {
             "version": "2.1.0",
@@ -1864,12 +1818,6 @@
                 "pbkdf2": "^3.1.2"
             }
         },
-        "node_modules/@types/json-bigint": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.4.tgz",
-            "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==",
-            "license": "MIT"
-        },
         "node_modules/@types/node": {
             "version": "20.12.12",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
@@ -2282,15 +2230,6 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "node_modules/cross-fetch": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-            "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "node-fetch": "^2.7.0"
-            }
-        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -2392,9 +2331,9 @@
             "license": "MIT"
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+            "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
             "funding": [
                 {
                     "type": "github",
@@ -2403,7 +2342,8 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "path-expression-matcher": "^1.1.3"
+                "path-expression-matcher": "^1.6.2",
+                "xml-naming": "^0.3.0"
             }
         },
         "node_modules/fast-xml-parser": {
@@ -2425,15 +2365,6 @@
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
-            }
-        },
-        "node_modules/fastq": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-            "license": "ISC",
-            "dependencies": {
-                "reusify": "^1.0.4"
             }
         },
         "node_modules/file-uri-to-path": {
@@ -2684,14 +2615,10 @@
             "license": "ISC"
         },
         "node_modules/ip-address": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
             "license": "MIT",
-            "dependencies": {
-                "jsbn": "1.1.0",
-                "sprintf-js": "^1.1.3"
-            },
             "engines": {
                 "node": ">= 12"
             }
@@ -2814,21 +2741,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/isomorphic-ws": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-            "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-            "license": "MIT",
-            "peerDependencies": {
-                "ws": "*"
-            }
-        },
-        "node_modules/jsbn": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-            "license": "MIT"
-        },
         "node_modules/level": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
@@ -2870,18 +2782,18 @@
             }
         },
         "node_modules/libsodium-sumo": {
-            "version": "0.7.16",
-            "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.16.tgz",
-            "integrity": "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.8.4.tgz",
+            "integrity": "sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==",
             "license": "ISC"
         },
         "node_modules/libsodium-wrappers-sumo": {
-            "version": "0.7.10",
-            "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.10.tgz",
-            "integrity": "sha512-1noz8Mcl/LUzO/iSO/FJzoJyIaPwxl+/+E4CoTIXtsPiEEXQx2sxalmrVWxteLpynqgX0ASo28ChB9NEVRh0Pg==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.8.4.tgz",
+            "integrity": "sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==",
             "license": "ISC",
             "dependencies": {
-                "libsodium-sumo": "^0.7.0"
+                "libsodium-sumo": "^0.8.0"
             }
         },
         "node_modules/lodash": {
@@ -2974,49 +2886,11 @@
             "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
             "license": "ISC"
         },
-        "node_modules/nanoid": {
-            "version": "3.3.11",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "bin": {
-                "nanoid": "bin/nanoid.cjs"
-            },
-            "engines": {
-                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-            }
-        },
         "node_modules/napi-macros": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
             "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==",
             "license": "MIT"
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
@@ -3073,9 +2947,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+            "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
             "funding": [
                 {
                     "type": "github",
@@ -3174,16 +3048,6 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "license": "MIT"
-        },
-        "node_modules/reusify": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-            "license": "MIT",
-            "engines": {
-                "iojs": ">=1.0.0",
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/ripemd160": {
             "version": "2.0.3",
@@ -3331,12 +3195,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3382,12 +3240,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "license": "MIT"
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "license": "MIT"
         },
         "node_modules/ts-custom-error": {
@@ -3515,22 +3367,6 @@
             "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==",
             "license": "MPL-2.0"
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
         "node_modules/which-typed-array": {
             "version": "1.1.20",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -3552,31 +3388,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+        "node_modules/xml-naming": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+            "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
             "license": "MIT",
             "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
+                "node": ">=16.0.0"
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "",
     "type": "module",
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,55 +510,32 @@
     multiformats "^13.0.1"
     uint8arrays "^5.0.1"
 
-"@cardano-ogmios/client@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.9.0.tgz"
-  integrity sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==
-  dependencies:
-    "@cardano-ogmios/schema" "6.9.0"
-    "@cardanosolutions/json-bigint" "^1.0.1"
-    "@types/json-bigint" "^1.0.1"
-    bech32 "^2.0.0"
-    cross-fetch "^3.1.4"
-    fastq "^1.11.0"
-    isomorphic-ws "^4.0.1"
-    nanoid "^3.1.31"
-    ts-custom-error "^3.2.0"
-    ws "^7.5.10"
-
-"@cardano-ogmios/schema@6.9.0":
-  version "6.9.0"
-  resolved "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.9.0.tgz"
-  integrity sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA==
-
 "@cardano-sdk/core@^0.46.12", "@cardano-sdk/core@~0.46.12":
-  version "0.46.12"
-  resolved "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.12.tgz"
-  integrity sha512-yUA/xBUQMiMqIWiZPvIhM911pL3jNKg4PkZQ8qP9R7yU3NQ5x4RQkZ+zFDlVLxUt+gJiwIW2es0iPd8ObIKCxA==
+  version "0.46.15"
+  resolved "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.15.tgz"
+  integrity sha512-ubfUpDaSSEGxfmdCvV8xN7niXy1cR3HX4dCA/zJH91GpuV5XGGttI5pFbxpqDZubYHU2lw+QQ2kWJJGHQmjbog==
   dependencies:
     "@biglup/is-cid" "^1.0.3"
-    "@cardano-ogmios/client" "6.9.0"
-    "@cardano-ogmios/schema" "6.9.0"
-    "@cardano-sdk/crypto" "~0.4.5"
-    "@cardano-sdk/util" "~0.17.1"
+    "@cardano-sdk/crypto" "~0.4.7"
+    "@cardano-sdk/util" "~0.17.2"
     "@foxglove/crc" "^0.0.3"
     "@scure/base" "^1.1.1"
     fraction.js "4.0.1"
-    ip-address "^9.0.5"
+    ip-address "^10.2.0"
     lodash "^4.17.21"
     ts-custom-error "^3.2.0"
     ts-log "^2.2.4"
     web-encoding "^1.1.5"
 
-"@cardano-sdk/crypto@~0.4.5":
-  version "0.4.5"
-  resolved "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.5.tgz"
-  integrity sha512-ymliqxdmen5dGVaiMVQ0VnhrwaYUjbPD3sHoMj8NI6MTuxrREp3pLJASREtWhwmv9k+QzDT6CoyuIXnlEQiWZQ==
+"@cardano-sdk/crypto@~0.4.5", "@cardano-sdk/crypto@~0.4.7":
+  version "0.4.7"
+  resolved "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.7.tgz"
+  integrity sha512-4aCsLOkqaIS/gSGw4SBqNGcCIp6hZ8alQWJx58U/OiOxC43t7i2JpKagdyWfCNekPM14hO7BWER7y31wf4BFxw==
   dependencies:
-    "@cardano-sdk/util" "~0.17.1"
+    "@cardano-sdk/util" "~0.17.2"
     blake2b "^2.1.4"
     i "^0.3.7"
-    libsodium-wrappers-sumo "0.7.10"
+    libsodium-wrappers-sumo "0.8.4"
     lodash "^4.17.21"
     pbkdf2 "^3.1.3"
     ts-custom-error "^3.2.0"
@@ -656,10 +633,16 @@
     ts-custom-error "^3.2.0"
     ts-log "^2.2.4"
 
-"@cardanosolutions/json-bigint@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/@cardanosolutions/json-bigint/-/json-bigint-1.1.0.tgz"
-  integrity sha512-Pdgz18cSwLKKgheOqW/dqbzNI+CliNT4AdaKaKY/P++J9qLxIB8MITCurlzbaFWV3W4nmK0CRQwI1yvuArmjFg==
+"@cardano-sdk/util@~0.17.2":
+  version "0.17.2"
+  resolved "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.2.tgz"
+  integrity sha512-LdY33OQG5H4p0rppHtjnM+akc1poKhz+02T9zsXsbShfTbeU9HXlA0nJ8xj9FNZMs+ozDR0HWrUjDc7fkNZI7w==
+  dependencies:
+    bech32 "^2.0.0"
+    lodash "^4.17.21"
+    serialize-error "^8"
+    ts-custom-error "^3.2.0"
+    ts-log "^2.2.4"
 
 "@chainsafe/is-ip@^2.0.1":
   version "2.1.0"
@@ -1181,11 +1164,6 @@
     hash.js "^1.1.7"
     pbkdf2 "^3.1.2"
 
-"@types/json-bigint@^1.0.1":
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.4.tgz"
-  integrity sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==
-
 "@types/node@^20.0":
   version "20.12.12"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz"
@@ -1417,13 +1395,6 @@ create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz"
-  integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
-  dependencies:
-    node-fetch "^2.7.0"
-
 define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz"
@@ -1488,11 +1459,12 @@ eventemitter3@^5.0.4:
   integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
 
 fast-xml-builder@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz"
-  integrity sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz"
+  integrity sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==
   dependencies:
-    path-expression-matcher "^1.1.3"
+    path-expression-matcher "^1.6.2"
+    xml-naming "^0.3.0"
 
 fast-xml-parser@5.7.2:
   version "5.7.2"
@@ -1503,13 +1475,6 @@ fast-xml-parser@5.7.2:
     fast-xml-builder "^1.1.5"
     path-expression-matcher "^1.5.0"
     strnum "^2.2.3"
-
-fastq@^1.11.0:
-  version "1.20.1"
-  resolved "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz"
-  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
-  dependencies:
-    reusify "^1.0.4"
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -1650,13 +1615,10 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ip-address@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz"
-  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
-  dependencies:
-    jsbn "1.1.0"
-    sprintf-js "^1.1.3"
+ip-address@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 is-arguments@^1.0.4:
   version "1.2.0"
@@ -1724,16 +1686,6 @@ iso-url@^1.1.3:
   resolved "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz"
   integrity sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==
 
-isomorphic-ws@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz"
-  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
-
-jsbn@1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz"
-  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
-
 level-supports@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz"
@@ -1756,17 +1708,17 @@ level@^8.0.1:
     browser-level "^1.0.1"
     classic-level "^1.2.0"
 
-libsodium-sumo@^0.7.0:
-  version "0.7.16"
-  resolved "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.16.tgz"
-  integrity sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==
+libsodium-sumo@^0.8.0:
+  version "0.8.4"
+  resolved "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.8.4.tgz"
+  integrity sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==
 
-libsodium-wrappers-sumo@0.7.10:
-  version "0.7.10"
-  resolved "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.10.tgz"
-  integrity sha512-1noz8Mcl/LUzO/iSO/FJzoJyIaPwxl+/+E4CoTIXtsPiEEXQx2sxalmrVWxteLpynqgX0ASo28ChB9NEVRh0Pg==
+libsodium-wrappers-sumo@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.8.4.tgz"
+  integrity sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==
   dependencies:
-    libsodium-sumo "^0.7.0"
+    libsodium-sumo "^0.8.0"
 
 lodash@^4.17.21:
   version "4.18.1"
@@ -1831,22 +1783,10 @@ nanoassert@^2.0.0:
   resolved "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz"
   integrity sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==
 
-nanoid@^3.1.31:
-  version "3.3.11"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
-
 napi-macros@^2.2.2:
   version "2.2.2"
   resolved "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz"
   integrity sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g==
-
-node-fetch@^2.7.0:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
 
 node-gyp-build@^4.3.0:
   version "4.8.4"
@@ -1876,10 +1816,10 @@ p-timeout@^7.0.0:
   resolved "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz"
   integrity sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==
 
-path-expression-matcher@^1.1.3, path-expression-matcher@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz"
-  integrity sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==
+path-expression-matcher@^1.5.0, path-expression-matcher@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz"
+  integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
 
 pbkdf2@^3.1.2, pbkdf2@^3.1.3:
   version "3.1.5"
@@ -1940,11 +1880,6 @@ readable-stream@^2.3.8:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
-
-reusify@^1.0.4:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
-  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.3:
   version "2.0.3"
@@ -2020,11 +1955,6 @@ sha.js@^2.4.0, sha.js@^2.4.12, sha.js@^2.4.8:
     safe-buffer "^5.2.1"
     to-buffer "^1.2.0"
 
-sprintf-js@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz"
-  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
-
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
@@ -2050,11 +1980,6 @@ to-buffer@^1.2.0, to-buffer@^1.2.1, to-buffer@^1.2.2:
     isarray "^2.0.5"
     safe-buffer "^5.2.1"
     typed-array-buffer "^1.0.3"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-custom-error@^3.2.0:
   version "3.3.1"
@@ -2152,19 +2077,6 @@ webextension-polyfill@^0.8.0:
   resolved "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz"
   integrity sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
-
 which-typed-array@^1.1.16, which-typed-array@^1.1.2:
   version "1.1.20"
   resolved "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz"
@@ -2178,12 +2090,12 @@ which-typed-array@^1.1.16, which-typed-array@^1.1.2:
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
 
-ws@*, ws@^7.5.10:
-  version "7.5.10"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 yaml@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz"
-  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
+  version "2.9.0"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
Summary:
- Ran native npm audit for the scheduled vulnerability rotation.
- Applied npm audit fix and refreshed package locks, clearing fixable advisories for @cardano-sdk/core/ip-address, fast-xml-builder, ws, and yaml.
- Bumped package version to 1.0.1.

Validation:
- npm install passed.
- npm run compile passed with Aiken on PATH.
- npm test passed: 58 tests, 52 passed, 6 skipped.

Remaining upstream-blocked advisories:
- GHSA-848j-6mx2-7j84 via @stricahq/bip32ed25519 -> elliptic; npm reports no fix available and @stricahq/bip32ed25519 latest 1.1.2 still pins elliptic 6.6.1.