### PR TITLE
Improve inventory personalization family coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "module",
     "scripts": {
         "compile": "node compileAiken.js",
-        "test": "node --test tests/aiken.cost.test.js tests/aiken.intentCoverage.test.js tests/buildPatchedSettingsDatum.test.js tests/cborSplice.test.js tests/compileAiken.test.js tests/deploymentPlan.test.js tests/deploymentState.test.js tests/mpfProofAdapter.test.js tests/persdsgWithdrawal.test.js tests/settingsUpdateTx.test.js"
+        "test": "python3 -m unittest tests/test_inventory_personalization_family.py && node --test tests/aiken.cost.test.js tests/aiken.intentCoverage.test.js tests/buildPatchedSettingsDatum.test.js tests/cborSplice.test.js tests/compileAiken.test.js tests/deploymentPlan.test.js tests/deploymentState.test.js tests/mpfProofAdapter.test.js tests/persdsgWithdrawal.test.js tests/settingsUpdateTx.test.js"
     },
     "author": "et",
     "license": "MIT",

--- a/tests/test_inventory_personalization_family.py
+++ b/tests/test_inventory_personalization_family.py
@@ -1,6 +1,10 @@
 from importlib.util import module_from_spec, spec_from_file_location
+import json
 from pathlib import Path
+import tempfile
 import unittest
+from unittest.mock import patch
+from urllib.error import HTTPError
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / 'scripts' / 'inventory_personalization_family.py'
@@ -10,6 +14,194 @@ SPEC.loader.exec_module(MODULE)
 
 
 class InventoryPersonalizationFamilyTests(unittest.TestCase):
+    def test_load_env_file_parses_quotes_and_ignores_comments(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            env_path = Path(tmpdir) / '.env'
+            env_path.write_text(
+                """
+# ignored
+KORA_USER_AGENT="kora coverage"
+SINGLE='quoted value'
+SPACED = plain value
+MISSING_EQUALS
+EMPTY=
+""".lstrip()
+            )
+
+            self.assertEqual(
+                MODULE.load_env_file(env_path),
+                {
+                    'KORA_USER_AGENT': 'kora coverage',
+                    'SINGLE': 'quoted value',
+                    'SPACED': 'plain value',
+                    'EMPTY': '',
+                },
+            )
+            self.assertEqual(MODULE.load_env_file(Path(tmpdir) / 'missing.env'), {})
+
+    def test_fetch_handle_and_script_cbor_treat_404_as_absent(self):
+        handle_error = HTTPError(
+            'https://preview.api.handle.me/handles/pers1@handlecontract',
+            404,
+            'not found',
+            hdrs=None,
+            fp=None,
+        )
+        with patch.object(MODULE, 'fetch_json', side_effect=handle_error) as fetch_json:
+            self.assertEqual(
+                MODULE.fetch_handle('pers1@handlecontract', 'preview', 'ua'),
+                {'exists': False, 'data': None},
+            )
+            fetch_json.assert_called_once_with(
+                'https://preview.api.handle.me/handles/pers1@handlecontract',
+                'ua',
+            )
+
+        script_error = HTTPError(
+            'https://preview.api.handle.me/handles/pers1@handlecontract/script',
+            404,
+            'not found',
+            hdrs=None,
+            fp=None,
+        )
+        with patch.object(MODULE, 'fetch_json', side_effect=script_error):
+            self.assertIsNone(MODULE.fetch_script_cbor('pers1@handlecontract', 'preview', 'ua'))
+
+        with patch.object(MODULE, 'fetch_json', return_value={'cborHex': '5901'}):
+            self.assertEqual(MODULE.fetch_script_cbor('pers1@handlecontract', 'preview', 'ua'), '5901')
+
+    def test_validator_hash_from_cbor_invokes_cardano_cli_and_removes_temp_file(self):
+        seen = {}
+
+        def fake_check_output(argv, text):
+            self.assertEqual(argv[:4], ['cardano-cli', 'hash', 'script', '--script-file'])
+            self.assertTrue(text)
+            script_path = Path(argv[-1])
+            seen['path'] = script_path
+            seen['script'] = json.loads(script_path.read_text())
+            self.assertTrue(script_path.exists())
+            return 'validatorhash\n'
+
+        with patch.object(MODULE.subprocess, 'check_output', side_effect=fake_check_output) as check_output:
+            self.assertEqual(MODULE.validator_hash_from_cbor('5901'), 'validatorhash')
+
+        check_output.assert_called_once()
+        self.assertEqual(
+            seen['script'],
+            {
+                'type': 'PlutusScriptV2',
+                'description': 'inventory-personalization-family',
+                'cborHex': '5901',
+            },
+        )
+        self.assertFalse(seen['path'].exists())
+        self.assertIsNone(MODULE.validator_hash_from_cbor(None))
+
+    def test_parse_static_mainnet_personalization_entries_filters_valid_contract_handles(self):
+        source_text = """
+export const scripts = {
+  preview: {
+    ignored_preview: { handle: 'pz_contract_preview', validatorHash: 'bad', cbor: 'bad' },
+  },
+  mainnet: {
+    first: {
+      handle: 'pz_contract_1',
+      validatorHash: 'vh1',
+      cbor: 'cbor1',
+      datumCbor: 'datum1',
+      latest: true,
+      nested: { text: 'brace } inside string' },
+    },
+    unrelated: {
+      handle: 'not_pz_contract',
+      validatorHash: 'vh2',
+      cbor: 'cbor2',
+    },
+    incomplete: {
+      handle: 'pz_contract_2',
+      validatorHash: 'vh3',
+    },
+    latest: {
+      handle: 'pz_contract_04',
+      validatorHash: 'vh4',
+      cbor: 'cbor4',
+      latest: false,
+    },
+  },
+  preprod: {
+    ignored_preprod: { handle: 'pz_contract_preprod', validatorHash: 'bad', cbor: 'bad' },
+  },
+}
+"""
+
+        with patch.object(MODULE.subprocess, 'check_output', return_value=source_text):
+            entries = MODULE.parse_static_mainnet_personalization_entries()
+
+        self.assertEqual(
+            entries,
+            [
+                {
+                    'handle': 'pz_contract_1',
+                    'static_address': 'first',
+                    'validator_hash': 'vh1',
+                    'cbor': 'cbor1',
+                    'datum_cbor': 'datum1',
+                    'latest': True,
+                },
+                {
+                    'handle': 'pz_contract_04',
+                    'static_address': 'latest',
+                    'validator_hash': 'vh4',
+                    'cbor': 'cbor4',
+                    'datum_cbor': None,
+                    'latest': False,
+                },
+            ],
+        )
+
+    def test_fetch_validator_handles_pages_until_reference_token_and_uses_cache(self):
+        handle_hex = '70657273314068616e646c65636f6e7472616374'
+        first_page = [{'asset_list': []} for _ in range(100)]
+        second_page = [
+            {
+                'asset_list': [
+                    {
+                        'policy_id': MODULE.POLICY,
+                        'asset_name': MODULE.REFERENCE_TOKEN_LABEL + handle_hex,
+                    }
+                ]
+            }
+        ]
+        calls = []
+
+        def fake_fetch_json(url, user_agent, *, method='GET', payload=None):
+            calls.append((url, user_agent, method, payload))
+            return first_page if len(calls) == 1 else second_page
+
+        cache = {}
+        with patch.object(MODULE, 'fetch_json', side_effect=fake_fetch_json):
+            self.assertEqual(MODULE.fetch_validator_handles('preview', 'ua', 'vh', cache), ['pers1@handlecontract'])
+            self.assertEqual(MODULE.fetch_validator_handles('preview', 'ua', 'vh', cache), ['pers1@handlecontract'])
+
+        self.assertEqual(len(calls), 2)
+        self.assertIn('offset=0', calls[0][0])
+        self.assertIn('offset=100', calls[1][0])
+        self.assertEqual(calls[0][1], 'ua')
+        self.assertEqual(calls[0][2], 'POST')
+        self.assertEqual(calls[0][3], {'_payment_credentials': ['vh'], '_extended': True})
+        self.assertEqual(MODULE.fetch_validator_handles('preview', 'ua', None, {}), [])
+        self.assertIsNone(
+            MODULE.find_handle_token(
+                [
+                    {
+                        'asset_list': [
+                            {'policy_id': MODULE.POLICY, 'asset_name': MODULE.REFERENCE_TOKEN_LABEL + 'nothex'}
+                        ]
+                    }
+                ]
+            )
+        )
+
     def test_build_live_versions_preserves_historical_personalization_versions(self):
         legacy = [
             {


### PR DESCRIPTION
Coverage rotation for scripts/inventory_personalization_family.py. Added focused unittest coverage for env parsing, 404 handling, script hashing temp-file cleanup, static mainnet entry parsing, and validator handle pagination/cache behavior; wired the Python tests into npm test. Verify: npm test passed.