### PR TITLE
chore: rotate vulnerability scan version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-personalization",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "",
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Summary:
- Ran npm audit for the scheduled vulnerability rotation.
- Bumped package version from 1.0.1 to 1.0.2 and refreshed package-lock.json.
- npm audit still reports upstream-blocked GHSA-848j-6mx2-7j84 via @stricahq/bip32ed25519 -> elliptic; no patched @stricahq/bip32ed25519 or elliptic version exists.

Validation:
- npm install passed.
- npm run compile passed with PATH including ~/.aiken/bin.
- npm test passed.

Upstream-blocked advisories:
- GHSA-848j-6mx2-7j84