### PR TITLE
Patch vulnerable ip-address dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-personalization",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "MIT",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",
@@ -2615,9 +2615,9 @@
             "license": "ISC"
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "",
     "type": "module",
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,9 +1616,9 @@ inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ip-address@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+  version "10.5.0"
+  resolved "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz"
+  integrity sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==
 
 is-arguments@^1.0.4:
   version "1.2.0"


### PR DESCRIPTION
Summary:
- Ran npm audit for the scheduled dependency-vulnerability rotation.
- npm audit fix refreshed npm/yarn lockfiles and upgraded transitive ip-address from 10.2.0 to 10.5.0, clearing GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, and GHSA-22jq-vg5j-6vgg.
- Bumped package version from 1.0.2 to 1.0.3.
- Remaining upstream-blocked advisory: GHSA-848j-6mx2-7j84 via @stricahq/bip32ed25519 -> elliptic 6.6.1; no patched elliptic release is currently available and npm reports fixAvailable=false.

Verification:
- npm install: passed
- npm run compile: passed with Aiken CLI on PATH
- npm test: passed (63 node tests + 12 python unittest cases)
- npm audit: remaining 2 low vulnerabilities are upstream-blocked