### PR TITLE
chore: rotate vulnerability scan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "handles-personalization",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MIT",
             "dependencies": {
                 "@aiken-lang/merkle-patricia-forestry": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "handles-personalization",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "",
     "type": "module",
     "scripts": {


### PR DESCRIPTION
Dependency vulnerability rotation for handles-personalization.

- Ran npm audit; remaining advisories are upstream-blocked: GHSA-848j-6mx2-7j84 via elliptic <=6.6.1 pulled by @stricahq/bip32ed25519, with no patched elliptic release or @stricahq/bip32ed25519 upgrade available.
- Bumped npm package patch version from 1.0.3 to 1.0.4 for the scheduled scan release trigger.
- Validation passed: npm install, npm run compile with aiken on PATH, and npm test.